### PR TITLE
Add __isset() method to DTO class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,12 @@
 # Changes History
 
+1.1.1
+-----
+Add **__isset** method to DTO to have proper properties check on object
+Improve DTO class description
+
 1.1.0
-_____
+-----
 Add PartialUpdateDto
 
 1.0.9

--- a/src/Dto.php
+++ b/src/Dto.php
@@ -49,6 +49,18 @@ abstract class Dto implements \JsonSerializable
         }
     }
 
+    /**
+     * Returns whether given property is set in DTO.
+     *
+     * @param string $name Property name to check
+     *
+     * @return boolean
+     */
+    public function __isset(string $name): bool
+    {
+        return in_array($name, static::getInstanceProperties()) && $this->$name !== null;
+    }
+
     protected static function getInstanceProperties(): array
     {
         $class = static::class;

--- a/src/Dto.php
+++ b/src/Dto.php
@@ -2,18 +2,27 @@
 
 namespace Saritasa;
 
+use JsonSerializable;
+use ReflectionClass;
 use Saritasa\Exceptions\NotImplementedException;
 use Saritasa\Traits\SimpleJsonSerialize;
 
 /**
- * Inherit this class and define protected fields to get read-only DTO
+ * Parent class of data transfer object. Can be used to transfer data between application layers.
+ * Inherit class and define protected properties to have read-only DTO.
  */
-abstract class Dto implements \JsonSerializable
+abstract class Dto implements JsonSerializable
 {
     use SimpleJsonSerialize;
 
     protected static $propertiesCache;
 
+    /**
+     * Parent class of data transfer object. Can be used to transfer data between application layers.
+     * Inherit class and define protected properties to have read-only DTO.
+     *
+     * @param mixed[] $data DTO properties values
+     */
     public function __construct(array $data)
     {
         foreach (static::getInstanceProperties() as $key) {
@@ -23,22 +32,29 @@ abstract class Dto implements \JsonSerializable
         }
     }
 
-    public function toArray()
+    /**
+     * Returns array representation of DTO properties.
+     *
+     * @return mixed[]
+     */
+    public function toArray(): array
     {
         $result = [];
         foreach (static::getInstanceProperties() as $key) {
             $result[$key] = $this->$key;
         }
+
         return $result;
     }
-
 
     /**
      * All instance fields are available as read-only properties
      *
      * @param string $name Name of private field to return
+     *
      * @return mixed
-     * @throws NotImplementedException
+     *
+     * @throws NotImplementedException When requested property is not defined in DTO
      */
     public function __get($name)
     {
@@ -66,7 +82,7 @@ abstract class Dto implements \JsonSerializable
         $class = static::class;
         if (!isset(static::$propertiesCache[$class])) {
             $cache = [];
-            $reflect = new \ReflectionClass($class);
+            $reflect = new ReflectionClass($class);
             foreach ($reflect->getProperties() as $property) {
                 if (!$property->isStatic()) {
                     $cache[] = $property->getName();
@@ -74,6 +90,7 @@ abstract class Dto implements \JsonSerializable
             }
             static::$propertiesCache[$class] = $cache;
         }
+
         return static::$propertiesCache[$class];
     }
 }

--- a/src/PartialUpdateDto.php
+++ b/src/PartialUpdateDto.php
@@ -17,7 +17,7 @@ class PartialUpdateDto extends Dto
         return $this->updatedFields;
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         $result = [];
         foreach ($this->updatedFields as $key) {

--- a/tests/DtoTest.php
+++ b/tests/DtoTest.php
@@ -59,7 +59,7 @@ class DtoTest extends TestCase
         $this->assertEquals('value1', $array['field1']);
         $this->assertEquals(2, $array['field2']);
     }
-    
+
     public function testToJson()
     {
         $dto = new ExampleDto([
@@ -85,6 +85,18 @@ class DtoTest extends TestCase
 
         $this->expectException(\Error::class);
         $dto->field1 = "test";
+    }
+
+    public function testIsSet()
+    {
+        $dto = new ExampleDto([
+            'field1' => 'value1',
+            'field2' => null
+        ]);
+
+        $this->assertTrue(isset($dto->field1));
+        $this->assertFalse(isset($dto->field2));
+        $this->assertFalse(isset($dto->field3));
     }
 }
 

--- a/tests/PartialUpdateDtoTest.php
+++ b/tests/PartialUpdateDtoTest.php
@@ -28,6 +28,13 @@ class PartialUpdateDtoTest extends TestCase
         Assert::assertEquals(1, count(array_keys($arr)));
         Assert::assertEquals('data2', $arr['field2']);
     }
+
+    public function testGetUpdatedFields()
+    {
+        $data = new ExamplePartialDto(['field2' => 'data2']);
+
+        Assert::assertEquals(['field2'], $data->getUpdatedFields());
+    }
 }
 
 class ExamplePartialDto extends PartialUpdateDto {


### PR DESCRIPTION
This method allows us to check that protected properties, that are have public access via **__get()** method is set.

Also without this method we can't use Illuminate Collection **pluck()** method to retrieve list of properties of DTOs